### PR TITLE
test: suggested updates for testing if typecheck middleware is installed

### DIFF
--- a/test-fixtures/skeleton-app/config/environment.js
+++ b/test-fixtures/skeleton-app/config/environment.js
@@ -4,6 +4,7 @@
 module.exports = function(environment) {
   return {
     environment,
-    modulePrefix: 'skeleton-app'
+    modulePrefix: 'skeleton-app',
+    rootURL: '/'
   };
 };

--- a/test-fixtures/skeleton-app/package.json
+++ b/test-fixtures/skeleton-app/package.json
@@ -5,6 +5,7 @@
     "ember-cli-htmlbars": "*",
     "ember-cli-babel": "*",
     "ember-source": "*",
+    "ember-qunit": "*",
     "loader.js": "*",
     "typescript": "*"
   },

--- a/test-fixtures/skeleton-app/testem.js
+++ b/test-fixtures/skeleton-app/testem.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  test_page: 'tests/index.html?hidepassed',
+  disable_watching: true,
+  launch_in_ci: ['Chrome'],
+  launch_in_dev: ['Chrome'],
+  browser_start_timeout: 120,
+  browser_args: {
+    Chrome: {
+      ci: [
+        // --no-sandbox is needed when running Chrome inside a container
+        process.env.CI ? '--no-sandbox' : null,
+        '--headless',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        '--mute-audio',
+        '--remote-debugging-port=0',
+        '--window-size=1440,900'
+      ].filter(Boolean)
+    }
+  }
+};

--- a/test-fixtures/skeleton-app/tests/index.html
+++ b/test-fixtures/skeleton-app/tests/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Dummy Tests</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {{content-for "head"}}
+    {{content-for "test-head"}}
+
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/skeleton-app.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+
+    {{content-for "head-footer"}}
+    {{content-for "test-head-footer"}}
+  </head>
+  <body>
+    {{content-for "body"}}
+    {{content-for "test-body"}}
+
+    <script src="/testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/skeleton-app.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
+
+    {{content-for "body-footer"}}
+    {{content-for "test-body-footer"}}
+  </body>
+</html>

--- a/test-fixtures/skeleton-app/tests/test-helper.ts
+++ b/test-fixtures/skeleton-app/tests/test-helper.ts
@@ -1,0 +1,3 @@
+import { start } from 'ember-qunit';
+
+start();

--- a/ts/addon.ts
+++ b/ts/addon.ts
@@ -10,6 +10,9 @@ import TypecheckMiddleware from './lib/typechecking/middleware';
 import { Application } from 'express';
 import walkSync from 'walk-sync';
 import fs from 'fs-extra';
+import logger from 'debug';
+
+const debug = logger('ember-cli-typescript:addon');
 
 export const ADDON_NAME = 'ember-cli-typescript';
 
@@ -47,13 +50,19 @@ export default addon({
 
   serverMiddleware({ app, options }) {
     if (!options || !options.path) {
+      debug('Installing typecheck server middleware');
       this._addTypecheckMiddleware(app);
+    } else {
+      debug('Skipping typecheck server middleware');
     }
   },
 
   testemMiddleware(app, options) {
     if (!options || !options.path) {
+      debug('Installing typecheck testem middleware');
       this._addTypecheckMiddleware(app);
+    } else {
+      debug('Skipping typecheck testem middleware');
     }
   },
 

--- a/ts/tests/acceptance/build-test.ts
+++ b/ts/tests/acceptance/build-test.ts
@@ -69,50 +69,30 @@ describe('Acceptance: build', function () {
     );
   });
 
-  it("doesn't launch type checking when --path used", async () => {
+  it("doesn't launch type checking for `ember serve` when --path is used", async () => {
     await app.build();
+
     let server = app.serve({
       args: ['--path', 'dist'],
-      env: { DEBUG: 'ember-cli-typescript|express:*' },
+      env: { DEBUG: 'ember-cli-typescript:addon' },
     });
-    let result = await server.raceForOutputs([
-      'ember-cli-typescript:typecheck-worker',
-      'Serving on',
-    ]);
-    expect(result).to.include('Serving on');
+
+    let result = await server.waitForOutput('Serving on');
+
+    expect(result).to.include('ember-cli-typescript:addon Skipping typecheck server middleware');
   });
 
-  it('does launch type checking when --path not used', async () => {
-    await app.build();
-    let server = app.serve({ env: { DEBUG: 'ember-cli-typescript|express:*' } });
-    let result = await server.raceForOutputs([
-      'ember-cli-typescript:typecheck-worker',
-      'Serving on',
-    ]);
-    expect(result).to.include('ember-cli-typescript:typecheck-worker');
-  });
+  it("doesn't launch type checking for `ember test` when --path is used", async () => {
+    await app.build({ args: ['--environment', 'test'] });
 
-  it("doesn't launch type checking when --path used for tests", async () => {
-    await app.build();
-    let test = app.test({
+    let result = await app.test({
       args: ['--path', 'dist'],
-      env: { DEBUG: 'ember-cli-typescript|express:*' },
+      env: { DEBUG: 'ember-cli-typescript:addon' },
     });
-    let result = await test.raceForOutputs([
-      'ember-cli-typescript:typecheck-worker',
-      'express:application',
-    ]);
-    expect(result).to.include('express:application');
-  });
 
-  it('does launch type checking when --path not used for tests', async () => {
-    await app.build();
-    let test = app.test({ env: { DEBUG: 'ember-cli-typescript|express:*' } });
-    let result = await test.raceForOutputs([
-      'ember-cli-typescript:typecheck-worker',
-      'express:application',
-    ]);
-    expect(result).to.include('ember-cli-typescript:typecheck-worker');
+    expect(result.all).to.include(
+      'ember-cli-typescript:addon Skipping typecheck testem middleware'
+    );
   });
 
   it('fails the build when noEmitOnError is set and an error is emitted', async () => {


### PR DESCRIPTION
@mrloop Thanks for your patience on https://github.com/typed-ember/ember-cli-typescript/pull/1148! We'd love to get that change in before our first 4.0 release candidate

I'm opening this PR to suggest a slightly different approach to testing whether the typecheck middleware is installed or not. You seemed to be having to jump through a lot of hoops to work around the fact that `ember test` in the skeleton app would never actually terminate, so this PR fixes the skeleton app's fixtures so that the tests will actually run to completion.

In addition to that change, I also updated the addon to emit debug messages indicating whether the typecheck middleware is being included or not so we have something easier to assert against.

I think those two changes together avoid a lot of the gymnastics we were forcing on you to test your change, so hopefully this is an improvement 🙂 